### PR TITLE
Add original author credit

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -322,3 +322,4 @@ bin/rake
 
 * Built with link:https://alchemists.io/projects/gemsmith[Gemsmith].
 * Engineered by link:https://alchemists.io/team/brooke_kuhlmann[Brooke Kuhlmann].
+* Originally created in 2008 by link:https://github.com/trans[Thomas Sawyer] (link:https://github.com/rubyworks[Rubyworks]).


### PR DESCRIPTION
Hi Brooke,

I'm Thomas Sawyer (Trans), the original creator of the XDG gem. I started the project back in 2008 and maintained it through 2012 before transferring gem ownership to you in 2019.

I noticed the Credits section doesn't mention the original authorship. This PR adds a line acknowledging that. I think it's a reasonable addition given the project's history.

Thanks for keeping the gem going — it looks like you've done great work with it.